### PR TITLE
Update the ball abuse time so as to match the code

### DIFF
--- a/referee.md
+++ b/referee.md
@@ -26,7 +26,7 @@ A global presentation of the different cases of what will be called "preemption"
 
 1. If a robot enters the opponent's defense zone, it will be penalized for 5s in the same way as for the previous point. (**penalty-‘nomdurobot’ + abusive_attack**)
 
-1. If a robot stays more than 5s within a 25cm radius of the ball, then it will be penalized for 5s. (**penalty-‘nameofrobot’ + ball_abuse**)
+1. If a robot stays more than 3s within a 25cm radius of the ball, then it will be penalized for 5s. (**penalty-‘nameofrobot’ + ball_abuse**)
 
 1. If the referee operator judges that a robot should be penalized, he can manually penalize it by 5s or more by clicking one or more times on the ![5s button](/assets/imgs/5s.png "5s button") button of the corresponding robot. He can also unpenalize it by clicking on ![cancel button](/assets/imgs/cancel.png "cancel button") . (**penalty-‘nameofrobot’ + manually penalized**)
 


### PR DESCRIPTION
In the code(https://github.com/robot-soccer-kit/robot-soccer-kit/blob/778474f27b2f4a86efdcc02fd5d2e8c929e98e6a/rsk/constants.py#L33C1-L33C35), the ball abuse time is set to 3sec.
However, in the documentation it was written 5sec. This can be confusing for programs that try not to be penalized for ball abuse.